### PR TITLE
Detect model when enabling entities

### DIFF
--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -29,6 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: JVCConfigEntry) -> bool:
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
         password=entry.data[CONF_PASSWORD],
+        timeout=1,
     )
 
     try:

--- a/homeassistant/components/jvc_projector/binary_sensor.py
+++ b/homeassistant/components/jvc_projector/binary_sensor.py
@@ -25,6 +25,7 @@ class JVCBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describe JVC binary sensor entity."""
 
     value_fn: Callable[[str | None], bool | None] = lambda x: x == "on"
+    enabled_default: bool | Callable[[JvcProjectorEntity], bool] = True
 
 
 JVC_BINARY_SENSORS = (
@@ -46,6 +47,7 @@ JVC_BINARY_SENSORS = (
         translation_key="jvc_eshift",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda x: x == const.ON if x is not None else None,
+        enabled_default=JvcProjectorEntity.has_eshift,
     ),
     JVCBinarySensorEntityDescription(
         key=const.KEY_SOURCE,
@@ -80,6 +82,11 @@ class JvcBinarySensor(JvcProjectorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.unique_id}_{description.key}"
+        self._attr_entity_registry_enabled_default = (
+            description.enabled_default(self)
+            if callable(description.enabled_default)
+            else description.enabled_default
+        )
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/jvc_projector/entity.py
+++ b/homeassistant/components/jvc_projector/entity.py
@@ -38,3 +38,13 @@ class JvcProjectorEntity(CoordinatorEntity[JvcProjectorDataUpdateCoordinator]):
     def device(self) -> JvcProjector:
         """Return the device representing the projector."""
         return self.coordinator.device
+
+    @staticmethod
+    def has_eshift(entity: JvcProjectorEntity) -> bool:
+        """Return if device has e-shift."""
+        return "NZ" in entity.device.model
+
+    @staticmethod
+    def has_laser(entity: JvcProjectorEntity) -> bool:
+        """Return if device has laser."""
+        return "NZ" in entity.device.model or "NX9" in entity.device.model

--- a/homeassistant/components/jvc_projector/entity.py
+++ b/homeassistant/components/jvc_projector/entity.py
@@ -42,7 +42,7 @@ class JvcProjectorEntity(CoordinatorEntity[JvcProjectorDataUpdateCoordinator]):
     @staticmethod
     def has_eshift(entity: JvcProjectorEntity) -> bool:
         """Return if device has e-shift."""
-        return "NZ" in entity.device.model
+        return "NZ" in entity.device.model or "NX9" in entity.device.model #nx9 is the only lamp model with eshift
 
     @staticmethod
     def has_laser(entity: JvcProjectorEntity) -> bool:

--- a/homeassistant/components/jvc_projector/icons.json
+++ b/homeassistant/components/jvc_projector/icons.json
@@ -11,6 +11,12 @@
     "select": {
       "input": {
         "default": "mdi:hdmi-port"
+      },
+      "anamorphic": {
+        "default": "mdi:stretch-to-page-outline"
+      },
+      "laser_power": {
+        "default": "mdi:brightness-5"
       }
     },
     "sensor": {

--- a/homeassistant/components/jvc_projector/select.py
+++ b/homeassistant/components/jvc_projector/select.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Final
 
 from jvcprojector.projector import JvcProjector, const
 
@@ -21,18 +20,7 @@ class JvcProjectorSelectDescription(SelectEntityDescription):
     """Describes JVC Projector select entities."""
 
     command: Callable[[JvcProjector, str], Awaitable[None]]
-
-
-# these options correspond to a command and its possible values
-# note low latency is intentionally excluded because you can't just turn it on you need to meet conditions first so you should instead switch picture modes
-OPTIONS: Final[dict[str, list[str]]] = {
-    "input": const.VAL_FUNCTION_INPUT,
-    "eshift": const.VAL_TOGGLE,
-    "installation_mode": const.VAL_INSTALLATION_MODE,
-    "anamorphic": const.VAL_ANAMORPHIC,
-    "laser_power": const.VAL_LASER_POWER,
-    "laser_dimming": const.VAL_LASER_DIMMING,
-}
+    enabled_default: bool | Callable[[JvcProjectorEntity], bool] = True
 
 
 # type safe command function for a select
@@ -45,16 +33,48 @@ def create_select_command(key: str) -> Callable[[JvcProjector, str], Awaitable[N
     return command
 
 
-# create a select for each option defined
-SELECTS: Final[list[JvcProjectorSelectDescription]] = [
+# these options correspond to a command and its possible values
+# note low latency is intentionally excluded because you can't just turn it on you need to meet conditions first so you should instead switch picture modes
+JVC_SELECTS = (
     JvcProjectorSelectDescription(
-        key=key,
-        translation_key=key,
-        options=list(options),
-        command=create_select_command(key),
-    )
-    for key, options in OPTIONS.items()
-]
+        key=const.KEY_INPUT,
+        translation_key=const.KEY_INPUT,
+        options=const.VAL_FUNCTION_INPUT,
+        command=create_select_command(const.KEY_INPUT),
+    ),
+    JvcProjectorSelectDescription(
+        key=const.KEY_INSTALLATION_MODE,
+        translation_key=const.KEY_INSTALLATION_MODE,
+        options=const.VAL_INSTALLATION_MODE,
+        command=create_select_command(const.KEY_INSTALLATION_MODE),
+    ),
+    JvcProjectorSelectDescription(
+        key=const.KEY_ANAMORPHIC,
+        translation_key=const.KEY_ANAMORPHIC,
+        options=const.VAL_ANAMORPHIC,
+        command=create_select_command(const.KEY_ANAMORPHIC),
+    ),
+    JvcProjectorSelectDescription(
+        key=const.KEY_ESHIFT,
+        translation_key=const.KEY_ESHIFT,
+        options=const.VAL_TOGGLE,
+        command=create_select_command(const.KEY_ESHIFT),
+        enabled_default=JvcProjectorEntity.has_eshift,
+    ),
+    JvcProjectorSelectDescription(
+        key=const.KEY_LASER_POWER,
+        translation_key=const.KEY_LASER_POWER,
+        options=const.VAL_LASER_POWER,
+        command=create_select_command(const.KEY_LASER_POWER),
+    ),
+    JvcProjectorSelectDescription(
+        key=const.KEY_LASER_DIMMING,
+        translation_key=const.KEY_LASER_DIMMING,
+        options=const.VAL_LASER_DIMMING,
+        command=create_select_command(const.KEY_LASER_DIMMING),
+        enabled_default=JvcProjectorEntity.has_laser,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -66,7 +86,8 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        JvcProjectorSelectEntity(coordinator, description) for description in SELECTS
+        JvcProjectorSelectEntity(coordinator, description)
+        for description in JVC_SELECTS
     )
 
 
@@ -84,6 +105,11 @@ class JvcProjectorSelectEntity(JvcProjectorEntity, SelectEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.unique_id}_{description.key}"
+        self._attr_entity_registry_enabled_default = (
+            description.enabled_default(self)
+            if callable(description.enabled_default)
+            else description.enabled_default
+        )
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/jvc_projector/strings.json
+++ b/homeassistant/components/jvc_projector/strings.json
@@ -88,7 +88,7 @@
         }
       },
       "laser_power": {
-        "name": "Laser Power",
+        "name": "Laser/Lamp Power",
         "state": {
           "low": "Low",
           "medium": "Medium",


### PR DESCRIPTION
Decided to take a shot at making the enabled entities a little more dynamic with some simple model/enable/disable logic. This helps cleanup the UI for 4k/lamp users a lot.

Also lowering the projector timeout to 1sec seems to solve a lot of the issue with sending commands during updates.